### PR TITLE
Storage provider to store in $_SESSION

### DIFF
--- a/src/OIDC/StorageProviders/SQLite.php
+++ b/src/OIDC/StorageProviders/SQLite.php
@@ -25,12 +25,12 @@
  * @copyright (C) 2016 onwards Microsoft Corporation (http://microsoft.com/)
  */
 
-namespace microsoft\adalphp\samples;
+namespace microsoft\adalphp\OIDC\StorageProviders;
 
 /**
  * OIDC Storage implementation using a sqlite database.
  */
-class Storage implements \microsoft\adalphp\OIDC\StorageInterface {
+class SQLite implements \microsoft\adalphp\OIDC\StorageInterface {
     /**
      * Constructor.
      *

--- a/src/OIDC/StorageProviders/Session.php
+++ b/src/OIDC/StorageProviders/Session.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright (c) 2016 Micorosft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author Jan Hajek <jan.hajek@thenetw.org>
+ * @license MIT
+ * @copyright (C) 2016 onwards Microsoft Corporation (http://microsoft.com/)
+ */
+
+namespace microsoft\adalphp\OIDC\StorageProviders;
+
+/**
+ * OIDC Storage implementation using a sqlite database.
+ */
+class Session implements \microsoft\adalphp\OIDC\StorageInterface {
+    /**
+     * Constructor.
+     *
+     */
+    public function __construct() {
+        if (session_status() == PHP_SESSION_NONE) {
+            session_start();
+        }
+    }
+
+    /**
+     * Store the state and corresponding nonce for an OIDC request.
+     *
+     * @param string $state The state value.
+     * @param string $nonce The nonce value.
+     * @param array $stateparams Additional data to be stored with the state.
+     * @return bool Success/Failure
+     */
+    public function store_state($state, $nonce, $stateparams) {
+        $_SESSION[get_class($this)][$state] = [
+            'nonce' => $nonce,
+            'additional' => $stateparams,
+        ];
+
+        return true;
+    }
+
+    /**
+     * Get a stored state record.
+     *
+     * @param string $state The state to look for,
+     * @return array List of additional data and the expected nonce.
+     */
+    public function get_state($state) {
+        if(isset($_SESSION[get_class($this)][$state])) {
+            $result = $_SESSION[get_class($this)][$state];
+
+            return [
+                $result['additional'],
+                $result['nonce'],
+            ];
+        } else {
+            throw new \Exception('Unknown state.');
+        }
+    }
+
+    /**
+     * Delete a state/nonce record based on the nonce.
+     *
+     * @param string $nonce The nonce to look for.
+     */
+    public function delete_state($nonce) {
+        if(isset($_SESSION[get_class($this)])) {
+            foreach($_SESSION[get_class($this)] as $key=>$value) {
+                if($value['nonce'] == $nonce) {
+                    unset($_SESSION[$key]);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/samples/login.php
+++ b/src/samples/login.php
@@ -29,7 +29,7 @@ require(__DIR__.'/../../vendor/autoload.php');
 
 // Construct.
 $httpclient = new \microsoft\adalphp\HttpClient;
-$storage = new \microsoft\adalphp\samples\Storage(__DIR__.'/storagedb.sqlite');
+$storage = new \microsoft\adalphp\OIDC\StorageProviders\SQLite(__DIR__.'/storagedb.sqlite');
 $client = new \microsoft\adalphp\AAD\Client($httpclient, $storage);
 
 // Set credentials.

--- a/src/samples/pwgrant.php
+++ b/src/samples/pwgrant.php
@@ -29,7 +29,7 @@ require(__DIR__.'/../../vendor/autoload.php');
 
 // Construct.
 $httpclient = new \microsoft\adalphp\HttpClient;
-$storage = new \microsoft\adalphp\samples\Storage(__DIR__.'/storagedb.sqlite');
+$storage = new \microsoft\adalphp\OIDC\StorageProviders\SQLite(__DIR__.'/storagedb.sqlite');
 $client = new \microsoft\adalphp\AAD\Client($httpclient, $storage);
 
 // Set credentials.

--- a/src/samples/redirect.php
+++ b/src/samples/redirect.php
@@ -29,7 +29,7 @@ require(__DIR__.'/../../vendor/autoload.php');
 
 // Construct.
 $httpclient = new \microsoft\adalphp\HttpClient;
-$storage = new \microsoft\adalphp\samples\Storage(__DIR__.'/storagedb.sqlite');
+$storage = new \microsoft\adalphp\OIDC\StorageProviders\SQLite(__DIR__.'/storagedb.sqlite');
 $client = new \microsoft\adalphp\AAD\Client($httpclient, $storage);
 
 // Set credentials.


### PR DESCRIPTION
Create a storage provider which implements the StorageInterface to store into $_SESSION. This should be more efficient in load balanced environments with shared storage and hgih traffic (Azure Web Apps).

This also adds a new namespace called `namespace microsoft\adalphp\OIDC\StorageProviders` which offers two storage providers - `SQLite` and `Session`. Personally, I would consider creating a wiki page for the storage provider documentation.